### PR TITLE
Log request errors

### DIFF
--- a/log_outgoing_requests/compat.py
+++ b/log_outgoing_requests/compat.py
@@ -1,3 +1,5 @@
+import traceback
+
 import django
 
 # Taken from djangorestframework, see
@@ -58,3 +60,8 @@ else:
 
 
 __all__ = ["parse_header_parameters"]
+
+
+def format_exception(exception: BaseException):
+    t, e, tb = type(exception), exception, exception.__traceback__
+    return traceback.format_exception(t, e, tb)

--- a/log_outgoing_requests/formatters.py
+++ b/log_outgoing_requests/formatters.py
@@ -1,5 +1,74 @@
 import logging
 import textwrap
+import traceback
+from typing import cast
+
+from requests import RequestException
+from requests.models import PreparedRequest, Response
+
+from .typing import RequestLogRecord, is_request_log_record
+
+
+def format_headers(headers) -> str:
+    return "\n".join(f"{k}: {v}" for k, v in headers.items())
+
+
+def format_body(content: str | bytes | None, prefix: str) -> str:
+    from .conf import settings
+
+    if settings.LOG_OUTGOING_REQUESTS_EMIT_BODY:
+        return f"\n{prefix} body:\n{content}"
+    return ""
+
+
+def format_request(req: PreparedRequest) -> str:
+    template = textwrap.dedent(
+        """
+        ---------------- request ----------------
+        {req.method} {req.url}
+        {reqhdrs} {request_body}
+    """
+    )
+    return template.format(
+        req=req,
+        reqhdrs=format_headers(req.headers),
+        request_body=format_body(req.body, "Request"),
+    )
+
+
+def format_response(resp: Response):
+    template = textwrap.dedent(
+        """
+        ---------------- response ----------------
+        {resp.status_code} {resp.reason} {resp.url}
+        {reshdrs} {response_body}
+
+    """
+    )
+    return template.format(
+        resp=resp,
+        reshdrs=format_headers(resp.headers),
+        response_body=format_body(resp.content, "Response"),
+    )
+
+
+def format_error(exception: RequestException) -> str:
+    template = textwrap.dedent(
+        """
+        ---------------- error ----------------
+        {msg}
+
+        {tb}
+    """
+    )
+    tb = "\n".join(traceback.format_exception(exception))
+    output = template.format(msg=str(exception), tb=tb)
+    if (request := exception.request) is None:
+        return output
+
+    # we have request information, let's include it
+    formatted_request = format_request(request)
+    return f"{formatted_request}\n{output}"
 
 
 class HttpFormatter(logging.Formatter):
@@ -19,15 +88,17 @@ class HttpFormatter(logging.Formatter):
         * Response headers
     """
 
-    def _formatHeaders(self, d):
-        return "\n".join(f"{k}: {v}" for k, v in d.items())
+    def _formatMessageWithResponse(self, record: RequestLogRecord) -> str:
+        return "{request}\n{response}".format(
+            request=format_request(record.req),
+            response=format_response(record.res),
+        )
 
-    def _formatBody(self, content: str, request_or_response: str) -> str:
-        from .conf import settings
-
-        if settings.LOG_OUTGOING_REQUESTS_EMIT_BODY:
-            return f"\n{request_or_response} body:\n{content}"
-        return ""
+    def _formatMessageException(self, record: RequestLogRecord) -> str:
+        assert record.exc_info is not None
+        exception = record.exc_info[1]
+        assert isinstance(exception, RequestException)
+        return format_error(exception)
 
     def formatMessage(self, record):
         result = super().formatMessage(record)
@@ -35,24 +106,19 @@ class HttpFormatter(logging.Formatter):
         if record.name != "requests":
             return result
 
-        result += textwrap.dedent(
-            """
-            ---------------- request ----------------
-            {req.method} {req.url}
-            {reqhdrs} {request_body}
+        if not is_request_log_record(record):
+            return result
+        record = cast(RequestLogRecord, record)
 
-            ---------------- response ----------------
-            {res.status_code} {res.reason} {res.url}
-            {reshdrs} {response_body}
+        # if there is a response, apply the happy-flow formatting
+        if getattr(record, "res", None) is not None:
+            output = self._formatMessageWithResponse(record)
+            return f"{result}{output}"
 
-        """
-        ).format(
-            req=record.req,
-            res=record.res,
-            reqhdrs=self._formatHeaders(record.req.headers),
-            reshdrs=self._formatHeaders(record.res.headers),
-            request_body=self._formatBody(record.req.body, "Request"),
-            response_body=self._formatBody(record.res.content, "Response"),
-        )
+        # if there is exception information, extract the details from that
+        if record.exc_info:
+            output = self._formatMessageException(record)
+            return f"{result}{output}"
 
+        # any other log record - use the default formatter
         return result

--- a/log_outgoing_requests/formatters.py
+++ b/log_outgoing_requests/formatters.py
@@ -89,6 +89,8 @@ class HttpFormatter(logging.Formatter):
     """
 
     def _formatMessageWithResponse(self, record: RequestLogRecord) -> str:
+        assert record.req is not None
+        assert record.res is not None
         return "{request}\n{response}".format(
             request=format_request(record.req),
             response=format_response(record.res),
@@ -97,7 +99,8 @@ class HttpFormatter(logging.Formatter):
     def _formatMessageException(self, record: RequestLogRecord) -> str:
         assert record.exc_info is not None
         exception = record.exc_info[1]
-        assert isinstance(exception, RequestException)
+        if not isinstance(exception, RequestException):
+            return ""
         return format_error(exception)
 
     def formatMessage(self, record):

--- a/log_outgoing_requests/formatters.py
+++ b/log_outgoing_requests/formatters.py
@@ -1,11 +1,11 @@
 import logging
 import textwrap
-import traceback
-from typing import cast
+from typing import Union, cast
 
 from requests import RequestException
 from requests.models import PreparedRequest, Response
 
+from .compat import format_exception
 from .typing import RequestLogRecord, is_request_log_record
 
 
@@ -13,7 +13,7 @@ def format_headers(headers) -> str:
     return "\n".join(f"{k}: {v}" for k, v in headers.items())
 
 
-def format_body(content: str | bytes | None, prefix: str) -> str:
+def format_body(content: Union[str, bytes, None], prefix: str) -> str:
     from .conf import settings
 
     if settings.LOG_OUTGOING_REQUESTS_EMIT_BODY:
@@ -61,7 +61,7 @@ def format_error(exception: RequestException) -> str:
         {tb}
     """
     )
-    tb = "\n".join(traceback.format_exception(exception))
+    tb = "\n".join(format_exception(exception))
     output = template.format(msg=str(exception), tb=tb)
     if (request := exception.request) is None:
         return output

--- a/log_outgoing_requests/typing.py
+++ b/log_outgoing_requests/typing.py
@@ -1,0 +1,21 @@
+import logging
+from datetime import datetime
+from typing import Union
+
+from requests.models import PreparedRequest, Response
+
+
+class RequestLogRecord(logging.LogRecord):
+    requested_at: datetime
+    req: PreparedRequest
+    res: Response
+
+
+AnyLogRecord = Union[logging.LogRecord, RequestLogRecord]
+
+
+def is_request_log_record(record: AnyLogRecord) -> bool:
+    attrs = ("requested_at", "req", "res")
+    if any(not hasattr(record, attr) for attr in attrs):
+        return False
+    return True

--- a/log_outgoing_requests/typing.py
+++ b/log_outgoing_requests/typing.py
@@ -1,14 +1,14 @@
 import logging
 from datetime import datetime
-from typing import Union
+from typing import Optional, Union
 
 from requests.models import PreparedRequest, Response
 
 
 class RequestLogRecord(logging.LogRecord):
     requested_at: datetime
-    req: PreparedRequest | None
-    res: Response | None
+    req: Optional[PreparedRequest]
+    res: Optional[Response]
 
 
 AnyLogRecord = Union[logging.LogRecord, RequestLogRecord]

--- a/log_outgoing_requests/typing.py
+++ b/log_outgoing_requests/typing.py
@@ -7,8 +7,8 @@ from requests.models import PreparedRequest, Response
 
 class RequestLogRecord(logging.LogRecord):
     requested_at: datetime
-    req: PreparedRequest
-    res: Response
+    req: PreparedRequest | None
+    res: Response | None
 
 
 AnyLogRecord = Union[logging.LogRecord, RequestLogRecord]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
 tests_require =
     pytest
     pytest-django
+    pytest-mock
     tox
     isort
     black
@@ -60,6 +61,7 @@ include =
 tests =
     pytest
     pytest-django
+    pytest-mock
     pyquery
     tox
     isort

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ def default_settings(settings):
     return settings
 
 
+@pytest.fixture
+def minimal_settings(settings):
+    settings.LOG_OUTGOING_REQUESTS_DB_SAVE = False
+    settings.LOG_OUTGOING_REQUESTS_EMIT_BODY = False
+
+
 #
 # requests data
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Global pytest fixtures"""
 
 import pytest
+from requests.models import Request
+from requests.sessions import Session
 
 from log_outgoing_requests.datastructures import ContentType
 
@@ -30,6 +32,14 @@ def minimal_settings(settings, mocker):
     mocker.patch(
         "log_outgoing_requests.handlers.DatabaseOutgoingRequestsHandler.emit",
     )
+
+
+@pytest.fixture
+def prepared_request():
+    # taken from requests.sessions.request
+    req = Request(method="GET", url="https://example.com")
+    session = Session()
+    return session.prepare_request(req)
 
 
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,15 @@ def default_settings(settings):
 
 
 @pytest.fixture
-def minimal_settings(settings):
+def minimal_settings(settings, mocker):
     settings.LOG_OUTGOING_REQUESTS_DB_SAVE = False
     settings.LOG_OUTGOING_REQUESTS_EMIT_BODY = False
+    # can't seem to actually modifiy settings.LOGGING to exclude the handler, since
+    # logging is configured in django's setup() phase and is then never run again.
+    # Additionally, we can't mock the solo model, since it's a local import...
+    mocker.patch(
+        "log_outgoing_requests.handlers.DatabaseOutgoingRequestsHandler.emit",
+    )
 
 
 #

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -6,6 +6,7 @@ from requests import RequestException
 
 from log_outgoing_requests.formatters import HttpFormatter
 from log_outgoing_requests.log_requests import log_errors
+from log_outgoing_requests.models import OutgoingRequestsLog
 
 
 def test_invalid_dns_name_error(minimal_settings, caplog):
@@ -68,3 +69,17 @@ def test_properly_format_http_error_responses(minimal_settings, caplog, requests
 
     assert "---------------- response ----------------" in res
     assert "500 Internal Server Error https://example.com" in res
+
+
+@pytest.mark.django_db
+def test_errored_request_error_information_recorded_in_db():
+    with pytest.raises(RequestException):
+        requests.get("https://e57f27db-ef2f-4475-98e8-cb3a4409cb3f")
+
+    request_log = OutgoingRequestsLog.objects.get()
+
+    assert request_log.url == "https://e57f27db-ef2f-4475-98e8-cb3a4409cb3f/"
+    assert request_log.method == "GET"
+    assert request_log.trace != ""
+    assert request_log.status_code is None
+    assert request_log.response_ms == 0

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -1,0 +1,35 @@
+import logging
+
+import pytest
+import requests
+from requests import RequestException
+
+
+def test_invalid_dns_name_error(minimal_settings, caplog):
+    # use bogus DNS name that should not resolve anywhere. We want the real requests
+    # behaviour here with the exact exceptions raised.
+    caplog.set_level(logging.DEBUG, logger="requests")
+    with pytest.raises(RequestException):
+        requests.get("https://e57f27db-ef2f-4475-98e8-cb3a4409cb3f")
+
+    assert len(caplog.records) == 1
+    assert "Outgoing request failed" in caplog.text
+
+
+def test_any_requests_exception_logged(minimal_settings, caplog, requests_mock):
+    caplog.set_level(logging.DEBUG, logger="requests")
+
+    # use locally scoped exception to check that the error handling mechanism can handle
+    # any requests.RequestException
+    class LocallyScopedException(RequestException):
+        pass
+
+    requests_mock.get(
+        "https://example.com", exc=LocallyScopedException("must be logged")
+    )
+
+    with pytest.raises(RequestException):
+        requests.get("https://example.com")
+
+    assert len(caplog.records) == 1
+    assert "Outgoing request error" in caplog.text

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 import requests
-from requests import HTTPError, RequestException
+from requests import RequestException
 
 from log_outgoing_requests.formatters import HttpFormatter
 from log_outgoing_requests.log_requests import log_errors

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -2,7 +2,10 @@ import logging
 
 import pytest
 import requests
-from requests import RequestException
+from requests import HTTPError, RequestException
+
+from log_outgoing_requests.formatters import HttpFormatter
+from log_outgoing_requests.log_requests import log_errors
 
 
 def test_invalid_dns_name_error(minimal_settings, caplog):
@@ -13,7 +16,7 @@ def test_invalid_dns_name_error(minimal_settings, caplog):
         requests.get("https://e57f27db-ef2f-4475-98e8-cb3a4409cb3f")
 
     assert len(caplog.records) == 1
-    assert "Outgoing request failed" in caplog.text
+    assert "Outgoing request error" in caplog.text
 
 
 def test_any_requests_exception_logged(minimal_settings, caplog, requests_mock):
@@ -33,3 +36,35 @@ def test_any_requests_exception_logged(minimal_settings, caplog, requests_mock):
 
     assert len(caplog.records) == 1
     assert "Outgoing request error" in caplog.text
+
+
+def test_properly_emit_exception_logs(prepared_request, minimal_settings, caplog):
+    caplog.set_level(logging.DEBUG, logger="requests")
+    formatter = HttpFormatter()
+
+    with pytest.raises(RequestException):
+        with log_errors():
+            raise RequestException("Something went wrong!", request=prepared_request)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    res = formatter.formatMessage(record)
+
+    assert "Something went wrong!" in res
+
+
+def test_properly_format_http_error_responses(minimal_settings, caplog, requests_mock):
+    caplog.set_level(logging.DEBUG, logger="requests")
+    requests_mock.get(
+        "https://example.com", status_code=500, reason="Internal Server Error"
+    )
+
+    requests.get("https://example.com")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    formatter = HttpFormatter()
+    res = formatter.formatMessage(record)
+
+    assert "---------------- response ----------------" in res
+    assert "500 Internal Server Error https://example.com" in res


### PR DESCRIPTION
Closes #15
Closes #18

* Capture request errors with a context manager and log them using stdlib logging
* Adapt custom formatter to handle log records with missing response (or request, even!)
* Adapt custom handler to store exception log records in DB

Requests has the convention to pass the `request` (and `response` if available) as init (kw)args to the exception classes. However, this is no guarantee - custom exception classes can exist and throw which do not have this information. The code is better type hinted and tested for these situations now.

The custom formatter and handler operate on the principle that if a response is available on the log record, it'll log request and response. Otherwise, if exception information is available, it is handled *only* if it's a requests exception. If possible, request information is extracted from the exception and logged too.

There are some more warts - determination if log records are our "own" based on whether certain magical attributes are present is not very tidy. Additionally, binding this to the `requests` logger instead of our own "namespace" is weird - you have to modify settings anyway to set it up. I hope to create a follow up PR to clean that up.