### PR TITLE
Feature/44 show content size

### DIFF
--- a/log_outgoing_requests/admin.py
+++ b/log_outgoing_requests/admin.py
@@ -25,6 +25,7 @@ class OutgoingRequestsLogAdmin(admin.ModelAdmin):
         "method",
         "response_ms",
         "timestamp",
+        "response_content_length",
     )
     list_filter = ("method", "timestamp", "status_code", "hostname")
     search_fields = ("url", "params", "hostname")
@@ -57,6 +58,7 @@ class OutgoingRequestsLogAdmin(admin.ModelAdmin):
                     "res_headers",
                     "res_content_type",
                     "res_body_encoding",
+                    "response_content_length",
                     "response_body",
                 )
             },
@@ -76,6 +78,7 @@ class OutgoingRequestsLogAdmin(admin.ModelAdmin):
         "response_ms",
         "res_headers",
         "res_content_type",
+        "response_content_length",
         "response_body",
         "trace",
     )

--- a/log_outgoing_requests/models.py
+++ b/log_outgoing_requests/models.py
@@ -174,6 +174,15 @@ class OutgoingRequestsLog(models.Model):
 
     response_body_decoded.short_description = _("Response body")  # type: ignore
 
+    @cached_property
+    def response_content_length(self) -> int:
+        """
+        Get Response content length by reading `len(response_body_decoded)`.
+        """
+        return len(self.response_body_decoded)
+
+    response_content_length.short_description = _("Response content length")  # type: ignore
+
 
 def get_default_max_content_length():
     """


### PR DESCRIPTION
Fixes: #44 

- Calculated the length of the response content based on body size
- Displayed value in List View and in Detail View
- Tests