### PR TITLE
Fix thread safety issues for streaming/gzipped/chunked responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           docker compose up -d
-          tox
+          tox -- -m ""
           docker compose down
         env:
           PYTHON_VERSION: ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
         run: pip install tox tox-gh-actions
 
       - name: Run tests
-        run: tox
+        run: |
+          docker compose up -d
+          tox
+          docker compose down
         env:
           PYTHON_VERSION: ${{ matrix.python }}
           DJANGO: ${{ matrix.django }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+---
+
+# Compose file to support unit tests, where requests are recorded with vcr.py.
+
+services:
+  # simple nginx service that returns a fixed gzipped response
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        cat >/etc/nginx/nginx.conf <<'EOF'
+        worker_processes  1;
+
+        events {
+          worker_connections  1024;
+        }
+
+        http {
+          include       /etc/nginx/mime.types;
+          default_type  application/octet-stream;
+          sendfile      on;
+
+          gzip on;
+          gzip_min_length 1;
+          gzip_types text/plain application/json;
+          gzip_vary off;
+          gzip_http_version 1.1;
+
+          server {
+            listen 80;
+            server_name _;
+
+            chunked_transfer_encoding on;
+
+            location = /gzip.txt {
+              root /usr/share/nginx/html;
+              default_type text/plain;
+            }
+          }
+        }
+        EOF
+
+        # Generate a body that's not huge, but large enough to make streaming/races
+        # more likely than with a tiny response. requests reads chunks of 10KiB
+        for i in $(seq 1 12000); do
+          echo "abcdefghijklmnopqrstuvwxyz0123456789 / line $$i" >> /usr/share/nginx/html/gzip.txt
+        done
+
+        exec nginx -g 'daemon off;'

--- a/log_outgoing_requests/handlers.py
+++ b/log_outgoing_requests/handlers.py
@@ -198,19 +198,15 @@ class QueueHandler(_QueueHandler):
             # we have an requests-specific exception
             exception = record.request_exception
             response = exception.response  # likely None
+        else:  # pragma: no cover
+            logger.debug("Received log record that cannot be handled %r", record)
+            return False
 
         # if we have a response, ensure that the content is consumed before the log
         # record it's queued to the background thread. See #58 for details.
-        if response is not None:
-            # streaming response are typically not something you want to see in logs
-            # because they're used for large responses that would consume excessive
-            # memory.
-            # TODO: add marker to avoid hitting response.content in downstream code so
-            # that we can still log metadata
-            is_streaming = record.stream
-            if is_streaming:
-                return False
-
+        # Note that we must take care not to load the entire body of a response into
+        # memory if the user requested response streaming.
+        if response is not None and not record.stream:
             # consume the content in the main thread so that the underlying
             # socket is not consumed from multiple places (this is the part that is not
             # thread-safe). Consumption of the content is supposed to happen in this
@@ -357,7 +353,9 @@ class DatabaseOutgoingRequestsHandler(logging.Handler):
             if (
                 response is not None
                 and (
-                    processed_response_body := process_body(response, config)
+                    processed_response_body := process_body(
+                        response, config, is_stream=record.stream
+                    )
                 ).allow_saving_to_db
             ):
                 kwargs.update(

--- a/log_outgoing_requests/handlers.py
+++ b/log_outgoing_requests/handlers.py
@@ -43,7 +43,6 @@ from requests import PreparedRequest, RequestException, Response
 from .conf import settings
 from .typing import (
     AnyLogRecord,
-    EventDict,
     is_any_request_log_record,
     is_error_request_log_record,
     is_request_log_record,
@@ -66,7 +65,7 @@ except ImportError:
     uwsgi = None
     postfork = lambda cb: None  # noqa: E731
 
-_queue: queue.Queue = queue.Queue[EventDict](maxsize=0)
+_queue: queue.Queue = queue.Queue[AnyLogRecord](maxsize=0)
 """
 Global queue singleton for the QueueHandler and QueueListener to communicate.
 

--- a/log_outgoing_requests/handlers.py
+++ b/log_outgoing_requests/handlers.py
@@ -203,15 +203,14 @@ class QueueHandler(_QueueHandler):
         # if we have a response, ensure that the content is consumed before the log
         # record it's queued to the background thread. See #58 for details.
         if response is not None:
-            # # fishy, private-ish API, but otherwise no reliable detection :(
-            # _is_streaming = response.raw is not None
-            # # streaming response are typically not something you want to see in logs
-            # # because they're used for large responses that would consume excessive
-            # # memory.
-            # # TODO: add marker to avoid hitting response.content in downstream code so
-            # # that we can still log metadata
-            # if _is_streaming:
-            #     return False
+            # streaming response are typically not something you want to see in logs
+            # because they're used for large responses that would consume excessive
+            # memory.
+            # TODO: add marker to avoid hitting response.content in downstream code so
+            # that we can still log metadata
+            is_streaming = record.stream
+            if is_streaming:
+                return False
 
             # consume the content in the main thread so that the underlying
             # socket is not consumed from multiple places (this is the part that is not

--- a/log_outgoing_requests/handlers.py
+++ b/log_outgoing_requests/handlers.py
@@ -168,11 +168,59 @@ def _stop_listener():
 
 class QueueHandler(_QueueHandler):
     """
-    Keep the raw log record.
+    Keep the raw log record and drop streaming responses.
 
     The stdlib implementation by default formats the log record to a string and clears
     most attributes to make them pickleable.
     """
+
+    def filter(self, record: AnyLogRecord) -> bool | logging.LogRecord:
+        """
+        Prevent unconsumed response bodies from being passed to the actual handler.
+
+        The response body must be consumed in the main thread to avoid thread-safety
+        issues when reading GZIP'ed responses in multiple threads, especially with
+        chunked transfer encodings where there's no content-length header available
+        where we check the size of `response.content` to decide if we can save the body
+        to the database or not.
+        """
+
+        # if it's not a log record produced by us, don't even bother sending it up the
+        # queue
+        if not is_any_request_log_record(record):
+            return False
+
+        response: Response | None = None
+
+        if is_request_log_record(record):
+            # we have a response - this is the 'happy' flow (connectivity is okay)
+            response = record.res
+        elif is_error_request_log_record(record):
+            # we have an requests-specific exception
+            exception = record.request_exception
+            response = exception.response  # likely None
+
+        # if we have a response, ensure that the content is consumed before the log
+        # record it's queued to the background thread. See #58 for details.
+        if response is not None:
+            # # fishy, private-ish API, but otherwise no reliable detection :(
+            # _is_streaming = response.raw is not None
+            # # streaming response are typically not something you want to see in logs
+            # # because they're used for large responses that would consume excessive
+            # # memory.
+            # # TODO: add marker to avoid hitting response.content in downstream code so
+            # # that we can still log metadata
+            # if _is_streaming:
+            #     return False
+
+            # consume the content in the main thread so that the underlying
+            # socket is not consumed from multiple places (this is the part that is not
+            # thread-safe). Consumption of the content is supposed to happen in this
+            # (main) thread anyway, assuming that requests aren't just made without
+            # checking the response content.
+            _ = response.content
+
+        return super().filter(record)
 
     def prepare(self, record: logging.LogRecord):
         return record

--- a/log_outgoing_requests/log_requests.py
+++ b/log_outgoing_requests/log_requests.py
@@ -14,19 +14,20 @@ def hook_requests_logging(response: Response, *args, **kwargs):
         extra={
             "req": response.request,
             "res": response,
+            "stream": kwargs.get("stream", False),
         },
     )
 
 
 @contextmanager
-def log_errors():
+def log_errors(*, stream: bool):
     try:
         yield
     except RequestException as exc:
         logger.debug(
             "outgoing_request_errored",
             exc_info=exc,
-            extra={"request_exception": exc},
+            extra={"request_exception": exc, "stream": stream},
         )
         raise
 
@@ -47,7 +48,7 @@ def install_outgoing_requests_logging():
     def new_request(self, *args, **kwargs):
         if hook_requests_logging not in self.hooks["response"]:
             self.hooks["response"].append(hook_requests_logging)
-        with log_errors():
+        with log_errors(stream=kwargs.get("stream", False)):
             return self._lor_initial_request(*args, **kwargs)
 
     Session.request = new_request

--- a/log_outgoing_requests/structlog.py
+++ b/log_outgoing_requests/structlog.py
@@ -36,6 +36,9 @@ class ExtractRequestAndResponseDetails:
       well. Additionally, the ``LOG_OUTGOING_REQUESTS_CONTENT_TYPES`` setting is
       checked for an allow-list of content types to log. Be careful when you enable
       this, as it can quickly explode your log storage.
+
+      Note that bodies from streaming responses (e.g.
+      ``requests.get(url, stream=True)``) are never extracted.
     :param body_max_content_length: If body extraction is enabled, this parameter
       controls the maximum size of bodies to be logged. Bodies that are larger will not
       be added to the event dict.
@@ -91,7 +94,7 @@ class ExtractRequestAndResponseDetails:
                     **self._process_headers(response.headers, "resp"),
                 }
             )
-            self._add_body_details(event_dict, response)
+            self._add_body_details(event_dict, response, is_stream=record.stream)
 
         return event_dict
 
@@ -121,6 +124,7 @@ class ExtractRequestAndResponseDetails:
         self,
         event_dict: EventDict,
         http_obj: PreparedRequest | Response,
+        is_stream: bool = False,
     ) -> None:
         from .models import OutgoingRequestsLogConfig
         from .utils import process_body
@@ -135,12 +139,15 @@ class ExtractRequestAndResponseDetails:
         config = OutgoingRequestsLogConfig(
             max_content_length=self.body_max_content_length
         )
-        body_details = process_body(http_obj, config)
+        body_details = process_body(http_obj, config, is_stream=is_stream)
+        event_dict.update(
+            {
+                f"{direction}_content_type": body_details.content_type,
+                f"{direction}_encoding": body_details.encoding,
+            }
+        )
         if content := body_details.content:
-            event_dict.update(
-                {
-                    f"{direction}_content_type": body_details.content_type,
-                    f"{direction}_encoding": body_details.encoding,
-                    f"{direction}_body": content,
-                }
-            )
+            event_dict[f"{direction}_body"] = content
+
+        if is_stream:
+            event_dict[f"{direction}_body_streaming"] = True

--- a/log_outgoing_requests/typing.py
+++ b/log_outgoing_requests/typing.py
@@ -16,6 +16,10 @@ class RequestLogRecord(logging.LogRecord):
 
     req: PreparedRequest
     res: Response
+    stream: bool
+    """
+    Captured value of the ``request(url, stream=...)`` kwarg.
+    """
 
 
 class ErrorRequestLogRecord(logging.LogRecord):
@@ -24,6 +28,10 @@ class ErrorRequestLogRecord(logging.LogRecord):
     """
 
     request_exception: RequestException
+    stream: bool
+    """
+    Captured value of the ``request(url, stream=...)`` kwarg.
+    """
 
 
 AnyLogRecord = logging.LogRecord | RequestLogRecord | ErrorRequestLogRecord

--- a/log_outgoing_requests/utils.py
+++ b/log_outgoing_requests/utils.py
@@ -17,15 +17,22 @@ logger = logging.getLogger(__name__)
 type HttpObj = PreparedRequest | Response
 
 
-def process_body(http_obj: HttpObj, config: OutgoingRequestsLogConfig) -> ProcessedBody:
+def process_body(
+    http_obj: HttpObj,
+    config: OutgoingRequestsLogConfig,
+    is_stream: bool = False,
+) -> ProcessedBody:
     """
     Process a request or response body by parsing the meta information.
     """
     content_type, encoding = parse_content_type_header(http_obj)
     if not encoding:
         encoding = get_default_encoding(content_type)
-    allow_persisting = check_content_type(content_type) and check_content_length(
-        http_obj, config=config
+    # never allow persisting/consumption of the request.content for streamed responses
+    allow_persisting = (
+        not is_stream
+        and check_content_type(content_type)
+        and check_content_length(http_obj, config=config)
     )
     content = _get_body(http_obj) if allow_persisting else b""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,12 @@ filterwarnings = [
 ]
 markers = [
     "real_db_close: do not patch timeline_logger.handlers.close_old_connections",
+    "live_http: tests that make live HTTP calls (and require docker compose)"
 ]
 env = [
     "_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER=true",
 ]
+addopts = "-m \"not live_http\""
 
 [tool.bumpversion]
 current_version = "0.9.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ class LogRecordEmitter:
         params: Mapping[str, str] = {"queryParam": "one"},
         data: bytes | Mapping[str, str] | None = None,
         response_status: int = 200,
+        stream: bool = False,
     ) -> RequestLogRecord | ErrorRequestLogRecord:
         record = logging.LogRecord(
             name="log_outgoing_requests",
@@ -90,6 +91,7 @@ class LogRecordEmitter:
 
         record.req = prepared_request
         record.res = response
+        record.stream = stream
         assert is_request_log_record(record)
         return record
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,6 @@ class LogRecordEmitter:
             args=None,
             exc_info=None,
         )
-        record._is_log_outgoing_requests = True
         prepared_request = Request(
             method=method, url=url, headers=headers, params=params, data=data
         ).prepare()

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -44,7 +44,7 @@ def test_properly_emit_exception_logs(prepared_request, minimal_settings, caplog
     formatter = HttpFormatter()
 
     with pytest.raises(RequestException):
-        with log_errors():
+        with log_errors(stream=False):
             raise RequestException("Something went wrong!", request=prepared_request)
 
     assert len(caplog.records) == 1

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -242,3 +242,65 @@ def test_integration_via_logging_dictconfig(
     assert OutgoingRequestsLog.objects.count() == 1
     log_obj = OutgoingRequestsLog.objects.get()
     assert log_obj.url == request_mock_kwargs["url"]
+
+
+@pytest.mark.real_db_close
+@pytest.mark.django_db(transaction=True)
+def test_logging_of_gzipped_response_is_thread_safe(
+    settings,
+    monkeypatch: pytest.MonkeyPatch,
+    _restore_logging_config,
+):
+    # Make sure to spin up the docker-compose.yml in the root of the repository, as a
+    # live HTTP service is required:
+    #
+    #   docker compose up
+    #
+    settings.LOG_OUTGOING_REQUESTS_HANDLER_USE_QUEUE = True
+    settings.LOG_OUTGOING_REQUESTS_MAX_CONTENT_LENGTH = 1024**3  # 1 MiB
+    monkeypatch.setenv("_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER", "false")
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "log_outgoing_requests": {
+                    "level": "DEBUG",
+                    "()": (
+                        "log_outgoing_requests.handlers"
+                        ".outgoing_requests_handler_factory"
+                    ),
+                    "buffer_size": 1,  # force immediate flush
+                    "flush_interval": 1,
+                },
+            },
+            "loggers": {
+                "log_outgoing_requests": {
+                    "handlers": ["log_outgoing_requests"],
+                    "level": "DEBUG",
+                    "propagate": False,
+                }
+            },
+        }
+    )
+    assert get_listener() is not None
+
+    def _make_gzip_request():
+        response = requests.get("http://localhost:8080/gzip.txt")
+        assert response.headers["Transfer-Encoding"] == "chunked"
+        assert response.headers["Content-Encoding"] == "gzip"
+        assert "Content-Length" not in response.headers
+        # consume the body
+        assert len(response.content) > 0
+
+    # this errors reliably-enough with a large enough response body, see the docker
+    # compose config
+    _make_gzip_request()
+
+    _queue.join()
+
+    assert OutgoingRequestsLog.objects.count() == 1
+    log_obj = OutgoingRequestsLog.objects.get()
+    assert log_obj.url == "http://localhost:8080/gzip.txt"
+    assert log_obj.response_content_length > 0
+    assert b"abcdefghijklmnopqrstuvwxyz0123456789" in log_obj.res_body

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -191,14 +191,6 @@ def test_handler_calls_on_error_callback_if_provided(
     assert len(errors_seen) == 1
 
 
-@pytest.fixture
-def _restore_logging_config(settings):
-    try:
-        yield
-    finally:
-        logging.config.dictConfig(settings.LOGGING)
-
-
 def test_queue_handler_plain_log_records():
     # log record masquerading as request log record, but it's missing the request
     # attributes
@@ -241,18 +233,10 @@ def test_queue_handler_request_exception_record_without_response(
     assert queued_record is log_record
 
 
-@pytest.mark.real_db_close
-@pytest.mark.django_db(transaction=True)
-def test_integration_via_logging_dictconfig(
-    settings,
-    monkeypatch: pytest.MonkeyPatch,
-    requests_mock,
-    request_mock_kwargs,
-    _restore_logging_config,
-):
+@pytest.fixture
+def enable_background_thread_logging(settings, monkeypatch: pytest.MonkeyPatch):
     settings.LOG_OUTGOING_REQUESTS_HANDLER_USE_QUEUE = True
     monkeypatch.setenv("_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER", "false")
-    requests_mock.get(**request_mock_kwargs)
     logging.config.dictConfig(
         {
             "version": 1,
@@ -278,6 +262,24 @@ def test_integration_via_logging_dictconfig(
         }
     )
     assert get_listener() is not None
+
+    try:
+        yield
+    finally:
+        # restore original config
+        logging.config.dictConfig(settings.LOGGING)
+
+
+@pytest.mark.real_db_close
+@pytest.mark.django_db(transaction=True)
+def test_integration_via_logging_dictconfig(
+    settings,
+    monkeypatch: pytest.MonkeyPatch,
+    requests_mock,
+    request_mock_kwargs,
+    enable_background_thread_logging,
+):
+    requests_mock.get(**request_mock_kwargs)
 
     requests.get(
         request_mock_kwargs["url"],
@@ -297,41 +299,14 @@ def test_integration_via_logging_dictconfig(
 def test_logging_of_gzipped_response_is_thread_safe(
     settings,
     monkeypatch: pytest.MonkeyPatch,
-    _restore_logging_config,
+    enable_background_thread_logging,
 ):
     # Make sure to spin up the docker-compose.yml in the root of the repository, as a
     # live HTTP service is required:
     #
     #   docker compose up
     #
-    settings.LOG_OUTGOING_REQUESTS_HANDLER_USE_QUEUE = True
     settings.LOG_OUTGOING_REQUESTS_MAX_CONTENT_LENGTH = 1024**3  # 1 MiB
-    monkeypatch.setenv("_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER", "false")
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "handlers": {
-                "log_outgoing_requests": {
-                    "level": "DEBUG",
-                    "()": (
-                        "log_outgoing_requests.handlers"
-                        ".outgoing_requests_handler_factory"
-                    ),
-                    "buffer_size": 1,  # force immediate flush
-                    "flush_interval": 1,
-                },
-            },
-            "loggers": {
-                "log_outgoing_requests": {
-                    "handlers": ["log_outgoing_requests"],
-                    "level": "DEBUG",
-                    "propagate": False,
-                }
-            },
-        }
-    )
-    assert get_listener() is not None
 
     def _make_gzip_request():
         response = requests.get("http://localhost:8080/gzip.txt")
@@ -360,41 +335,14 @@ def test_logging_of_gzipped_response_is_thread_safe(
 def test_logging_of_gzipped_response_with_streaming_is_skipped_to_avoid_memory_impact(
     settings,
     monkeypatch: pytest.MonkeyPatch,
-    _restore_logging_config,
+    enable_background_thread_logging,
 ):
     # Make sure to spin up the docker-compose.yml in the root of the repository, as a
     # live HTTP service is required:
     #
     #   docker compose up
     #
-    settings.LOG_OUTGOING_REQUESTS_HANDLER_USE_QUEUE = True
     settings.LOG_OUTGOING_REQUESTS_MAX_CONTENT_LENGTH = 1024**3  # 1 MiB
-    monkeypatch.setenv("_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER", "false")
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "handlers": {
-                "log_outgoing_requests": {
-                    "level": "DEBUG",
-                    "()": (
-                        "log_outgoing_requests.handlers"
-                        ".outgoing_requests_handler_factory"
-                    ),
-                    "buffer_size": 1,  # force immediate flush
-                    "flush_interval": 1,
-                },
-            },
-            "loggers": {
-                "log_outgoing_requests": {
-                    "handlers": ["log_outgoing_requests"],
-                    "level": "DEBUG",
-                    "propagate": False,
-                }
-            },
-        }
-    )
-    assert get_listener() is not None
 
     def _make_streaming_request():
         # make a request in streaming mode and validate that the content can be consumed

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -365,4 +365,9 @@ def test_logging_of_gzipped_response_with_streaming_is_skipped_to_avoid_memory_i
 
     _queue.join()
 
-    assert OutgoingRequestsLog.objects.exists() is False
+    # we do expect the metadata to be logged, but no body to be logged
+    assert OutgoingRequestsLog.objects.count() == 1
+    log_obj = OutgoingRequestsLog.objects.get()
+    assert log_obj.url == "http://localhost:8080/gzip.txt"
+    assert not log_obj.response_content_length
+    assert log_obj.res_body == b""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -304,3 +304,68 @@ def test_logging_of_gzipped_response_is_thread_safe(
     assert log_obj.url == "http://localhost:8080/gzip.txt"
     assert log_obj.response_content_length > 0
     assert b"abcdefghijklmnopqrstuvwxyz0123456789" in log_obj.res_body
+
+
+@pytest.mark.real_db_close
+@pytest.mark.django_db(transaction=True)
+def test_logging_of_gzipped_response_with_streaming_is_skipped_to_avoid_memory_impact(
+    settings,
+    monkeypatch: pytest.MonkeyPatch,
+    _restore_logging_config,
+):
+    # Make sure to spin up the docker-compose.yml in the root of the repository, as a
+    # live HTTP service is required:
+    #
+    #   docker compose up
+    #
+    settings.LOG_OUTGOING_REQUESTS_HANDLER_USE_QUEUE = True
+    settings.LOG_OUTGOING_REQUESTS_MAX_CONTENT_LENGTH = 1024**3  # 1 MiB
+    monkeypatch.setenv("_LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER", "false")
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "log_outgoing_requests": {
+                    "level": "DEBUG",
+                    "()": (
+                        "log_outgoing_requests.handlers"
+                        ".outgoing_requests_handler_factory"
+                    ),
+                    "buffer_size": 1,  # force immediate flush
+                    "flush_interval": 1,
+                },
+            },
+            "loggers": {
+                "log_outgoing_requests": {
+                    "handlers": ["log_outgoing_requests"],
+                    "level": "DEBUG",
+                    "propagate": False,
+                }
+            },
+        }
+    )
+    assert get_listener() is not None
+
+    def _make_streaming_request():
+        # make a request in streaming mode and validate that the content can be consumed
+        response = requests.get("http://localhost:8080/gzip.txt", stream=True)
+        assert response.status_code == 200
+        assert response.headers["Transfer-Encoding"] == "chunked"
+        assert response.headers["Content-Encoding"] == "gzip"
+        assert "Content-Length" not in response.headers
+
+        # consume the body
+        num_chunks = 0
+        for _ in response.iter_content(chunk_size=1024 * 8):  # 8 KiB chunks
+            num_chunks += 1
+
+        assert num_chunks > 0
+
+    # this errors reliably-enough with a large enough response body, see the docker
+    # compose config
+    _make_streaming_request()
+
+    _queue.join()
+
+    assert OutgoingRequestsLog.objects.exists() is False

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,5 +1,6 @@
 import logging
 import logging.config
+import queue
 import time
 from contextlib import nullcontext
 from unittest.mock import patch
@@ -16,6 +17,10 @@ from log_outgoing_requests.handlers import (
     outgoing_requests_handler_factory,
 )
 from log_outgoing_requests.models import OutgoingRequestsLog
+from log_outgoing_requests.typing import (
+    is_error_request_log_record,
+    is_request_log_record,
+)
 
 from .conftest import LogRecordEmitter
 
@@ -192,6 +197,48 @@ def _restore_logging_config(settings):
         yield
     finally:
         logging.config.dictConfig(settings.LOGGING)
+
+
+def test_queue_handler_plain_log_records():
+    # log record masquerading as request log record, but it's missing the request
+    # attributes
+    record = logging.LogRecord(
+        name="log_outgoing_requests",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="dummy",
+        args=None,
+        exc_info=None,
+    )
+    test_queue = queue.Queue(maxsize=1)
+    handler = QueueHandler(test_queue)
+
+    handler.handle(record)
+
+    with pytest.raises(queue.Empty):
+        test_queue.get_nowait()
+
+
+def test_queue_handler_request_exception_record_without_response(
+    log_record_emitter: LogRecordEmitter,
+):
+    log_record = log_record_emitter()
+    assert is_request_log_record(log_record)
+    log_record.request_exception = requests.RequestException(
+        request=log_record.req,
+        response=None,
+    )
+    del log_record.req
+    del log_record.res
+    assert is_error_request_log_record(log_record)
+    test_queue = queue.Queue(maxsize=1)
+    handler = QueueHandler(test_queue)
+
+    handler.handle(log_record)
+
+    queued_record = test_queue.get_nowait()
+    assert queued_record is log_record
 
 
 @pytest.mark.real_db_close

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -244,6 +244,7 @@ def test_integration_via_logging_dictconfig(
     assert log_obj.url == request_mock_kwargs["url"]
 
 
+@pytest.mark.live_http
 @pytest.mark.real_db_close
 @pytest.mark.django_db(transaction=True)
 def test_logging_of_gzipped_response_is_thread_safe(
@@ -306,6 +307,7 @@ def test_logging_of_gzipped_response_is_thread_safe(
     assert b"abcdefghijklmnopqrstuvwxyz0123456789" in log_obj.res_body
 
 
+@pytest.mark.live_http
 @pytest.mark.real_db_close
 @pytest.mark.django_db(transaction=True)
 def test_logging_of_gzipped_response_with_streaming_is_skipped_to_avoid_memory_impact(

--- a/tests/test_structlog.py
+++ b/tests/test_structlog.py
@@ -101,12 +101,35 @@ def test_too_large_bodies_are_not_emitted(log_record_emitter: LogRecordEmitter):
 
     updated_event_dict = processor(logger, "debug", event_dict)
 
-    assert "req_content_type" not in updated_event_dict
-    assert "req_encoding" not in updated_event_dict
+    assert "req_content_type" in updated_event_dict
+    assert "req_encoding" in updated_event_dict
     assert "req_body" not in updated_event_dict
-    assert "resp_content_type" not in updated_event_dict
-    assert "resp_encoding" not in updated_event_dict
+    assert "resp_content_type" in updated_event_dict
+    assert "resp_encoding" in updated_event_dict
     assert "resp_body" not in updated_event_dict
+
+
+def test_streaming_response_bodies_are_not_emitted(
+    log_record_emitter: LogRecordEmitter,
+):
+    log_record = log_record_emitter(
+        method="POST",
+        data=rb"{\"key\": 3}",
+        headers={"Content-Type": "application/json"},
+        stream=True,
+    )
+    event_dict = _make_event_dict(log_record)
+    processor = ExtractRequestAndResponseDetails(extract_bodies=True)
+
+    updated_event_dict = processor(logger, "debug", event_dict)
+
+    assert updated_event_dict["req_content_type"] == "application/json"
+    assert updated_event_dict["req_encoding"] == "utf-8"
+    assert updated_event_dict["req_body"] == rb"{\"key\": 3}"
+    assert updated_event_dict["resp_content_type"] == "text/plain"
+    assert updated_event_dict["resp_encoding"] == "utf-8"
+    assert "resp_body" not in updated_event_dict
+    assert updated_event_dict["resp_body_streaming"] is True
 
 
 def test_extracts_from_errored_requests(log_record_emitter: LogRecordEmitter):


### PR DESCRIPTION
Closes #58

Ensure that the body is consumed in the main thread before the background thread has a chance to try to decode it, as that would lead to concurrent consumption of the underlying socket and that blows up spectacularly.

VCR can't be used, because it records the already-decoded response, which is done via requests and urllib3 and cannot be configured.